### PR TITLE
Make GPL License explicit

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -7,19 +7,18 @@
 
 ;; This file is not part of GNU Emacs.
 
-;; GNU Emacs is free software: you can redistribute it and/or modify
+;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
 
-;; GNU Emacs is distributed in the hope that it will be useful,
+;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 
 ;; You should have received a copy of the GNU General Public License
-;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
-
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ;;; Commentary:
 
 ;; This library implements a Markdown back-end (hugo flavor) for Org


### PR DESCRIPTION
The current header text doesn't explicitly state that `ox-hugo.el` is GPL.  This change fixes that, if you would like to keep it that way..